### PR TITLE
Fixed key reset after app boot

### DIFF
--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -88,7 +88,7 @@ final class CaptchaServiceProvider implements ServiceProviderInterface, Bootable
      */
     public function boot(Application $app)
     {
-        $app['captcha']->generate(); // Initialize stored captcha so its value is never empty
+        $app['captcha']->generate($app['session']->get($app['captcha.session_key'])); // Initialize stored captcha so its value is never empty
     }
 
     /**


### PR DESCRIPTION
Generation of captcha key after boot was causing that key submitted by form was invalid all the time